### PR TITLE
소개 문구가 있는 탭을 추가

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,12 +1,17 @@
 import { Box, Heading, Tabs, Text } from 'dracula-ui';
 import { useState } from 'react';
 import BookingView from './BookingView';
-import './App.css';
 import WaitingView from './WaitingView';
+import WelcomeView from './WelcomeView';
+import './App.css';
 
 function App() {
   const [tabNo, setTabNo] = useState(0);
   const tabs = [
+    {
+      label: '소개',
+      viewComponent: <WelcomeView />,
+    },
     {
       label: '예매',
       viewComponent: <BookingView />,

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -5,7 +5,17 @@ import './App.css';
 import WaitingView from './WaitingView';
 
 function App() {
-  const [tab, setTab] = useState('book');
+  const [tabNo, setTabNo] = useState(0);
+  const tabs = [
+    {
+      label: '예매',
+      viewComponent: <BookingView />,
+    },
+    {
+      label: '대기 중',
+      viewComponent: <WaitingView />,
+    },
+  ];
   return (
     <Box className="App" width="full" mx="auto" my="xs">
       <Box className="heading" my="sm">
@@ -14,30 +24,25 @@ function App() {
         </Heading>
       </Box>
       <Tabs className="tabs">
-        <li
-          className={[
-            'drac-tab',
-            tab === 'book' ? 'drac-tab-active' : ''
-          ].join(' ')}
-          onClick={() => setTab('book')}
-        >
-          <Text>예매</Text>
-        </li>
-        <li
-          className={[
-            'drac-tab',
-            tab === 'waiting' ? 'drac-tab-active' : ''
-          ].join(' ')}
-          onClick={() => setTab('waiting')}
-        >
-          <Text>대기 중</Text>
-        </li>
-      </Tabs>
       {
-        tab === 'book' ?
-        <BookingView /> :
-        <WaitingView />
+        tabs.map((tabItem, index) =>
+          <li
+            key={[
+              tabItem.label,
+              tabNo === index ? 'active' : ''
+            ].join(' ')}
+            className={[
+              'drac-tab',
+              tabNo === index ? 'drac-tab-active' : ''
+            ].join(' ')}
+            onClick={() => setTabNo(index)}
+          >
+            <Text>{ tabItem.label }</Text>
+          </li>
+        )
       }
+      </Tabs>
+      { tabs[tabNo].viewComponent }
     </Box>
   );
 }

--- a/web/src/WelcomeView.css
+++ b/web/src/WelcomeView.css
@@ -1,0 +1,3 @@
+.WelcomeView .drac-text {
+  word-break: keep-all;
+}

--- a/web/src/WelcomeView.js
+++ b/web/src/WelcomeView.js
@@ -1,0 +1,21 @@
+import { Box, Card, Paragraph, Text } from 'dracula-ui';
+import './WelcomeView.css';
+
+function WelcomeView() {
+  return (
+    <Box className="WelcomeView">
+      <Card color="purpleCyan" p="sm" m="md">
+        <Text color="black">🚄 취소표라도 간절한 당신에게 기차표를 구해드립니다. 🚄</Text>
+      </Card>
+      <Paragraph align="left"  px="sm">
+        <b>취소표가 필요해</b>는 원하는 시간대의 코레일 기차표를 대신 예매해주는 서비스입니다.
+        원하는 시간대의 기차표가 매진되었을 때 취소표를 누구보다 빠르게 찾아서 예매해드립니다.
+      </Paragraph>
+      <Paragraph align="left" px="sm">
+        예매 탭에서 원하는 일정을 입력하시면 대기열에 등록되고, 취소표가 생기면 차례로 배정됩니다.
+      </Paragraph>
+    </Box>
+  );
+}
+
+export default WelcomeView;


### PR DESCRIPTION
# 개요

소개 탭을 추가하면서 탭을 렌더링 하는 방식을 수정했습니다.

1. 소개 문구와 사용법을 담은 `WelcomeView`라는 컴포넌트를 추가했습니다.
2. 탭을 렌더링하는 방식을 수정했습니다.

# 상세

기존 방식 - 탭의 이름을 상태로 사용
- 탭 버튼 : 직접 작성함
- 해당 뷰 : 3항 연산자로 상태에 따라 렌더링

---

새 방식 : 탭에 대한 정보를 담은 리스트 `tabs`를 두고, 현재 탭의 인덱스를 상태로 사용
- 탭 버튼 : `tabs.map`을 통해 렌더링
- 해당 뷰 : `{ tabs[tabNo].viewComponent }`와 같이 렌더링