### PR TITLE
응답 형식을 JSend로 설정

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -41,5 +41,5 @@ def create_ticket(
     """Create ticket reservation"""
     return {
         "status": "success",
-        "data": crud.create_ticket(db_session=db_session, ticket=ticket)
+        "data": crud.create_ticket(db_session=db_session, ticket=ticket),
     }

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -33,10 +33,13 @@ async def test():
     }
 
 
-@app.post("/tickets", response_model=schema.Ticket)
+@app.post("/tickets", response_model=schema.TicketJSend)
 def create_ticket(
     ticket: schema.TicketCreate,
     db_session: Session=Depends(get_db_session)
 ):
     """Create ticket reservation"""
-    return crud.create_ticket(db_session=db_session, ticket=ticket)
+    return {
+        "status": "success",
+        "data": crud.create_ticket(db_session=db_session, ticket=ticket)
+    }

--- a/server/api/schema.py
+++ b/server/api/schema.py
@@ -21,7 +21,7 @@ class TicketCreate(TicketBase):
     korail_pw: str
 
 
-class Ticket(TicketBase):
+class TicketRead(TicketBase):
     """Ticket schema for read request"""
     id: int
     reserved: bool
@@ -29,3 +29,8 @@ class Ticket(TicketBase):
     class Config:
         """Configuration for ORM support"""
         orm_mode = True
+
+class TicketJSend(BaseModel):
+    """Ticket response model in JSend format"""
+    status: str
+    data: TicketRead

--- a/server/api/schema.py
+++ b/server/api/schema.py
@@ -31,7 +31,13 @@ class TicketRead(TicketBase):
         """Configuration for ORM support"""
         orm_mode = True
 
-class TicketJSend(BaseModel):
-    """Ticket response model in JSend format"""
+
+class JSendModel(BaseModel):
+    """JSend format base model"""
     status: str
+    data: dict
+
+
+class TicketJSend(JSendModel):
+    """Ticket response model in JSend format"""
     data: TicketRead

--- a/server/api/schema.py
+++ b/server/api/schema.py
@@ -1,5 +1,6 @@
 """Pydantic models
 
+Pydantic models are used as type in FastAPI.
 Since the term model is used in SQLAlchemy and means different things, used
 schema instead.
 """


### PR DESCRIPTION
`status`와 `data`를 가지는 `JSendModel`을 추가해서 이를 상속하는 `TicketJSend` 모델을 만들었습니다.
`POST /tickets`의 응답 형식을 `TicketJSend`로 설정했습니다.

closes #5