### PR TITLE
Add multiple allow origins feature

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -22,9 +22,7 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        environ["CORS_ALLOW_URL"],
-    ],
+    allow_origins=environ["CORS_ALLOW_URL"].split(","),
     allow_credentials=True,
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],


### PR DESCRIPTION
`.env`에 `CORS_ALLOW_URL=http://localhost:3000,http://localhost:4000` 같은 식으로 여러 URL을 허용할 수 있다.