### PR TITLE
Fix `get_tickets` function args

### DIFF
--- a/server/api/crud.py
+++ b/server/api/crud.py
@@ -1,5 +1,7 @@
 """CRUD functions
 """
+from datetime import datetime
+
 from sqlalchemy.orm import Session
 
 from . import model, schema
@@ -27,26 +29,20 @@ def get_tickets(
     db_session: Session,
     skip: int=0,
     limit: int=100,
-    date=None,
-    dep=None,
-    arr=None,
-    dep_base=None,
-    arr_limit=None,
+    after_now: bool=False,
     reserved: bool=None,
     running: bool=None,
 ) -> list[model.Ticket]:
     """Get ticket reservation records in DB"""
     query = db_session.query(model.Ticket)
-    if date is not None:
-        query = query.filter(model.Ticket.date >= date)
-    if dep is not None:
-        query = query.filter(model.Ticket.departure_station == dep)
-    if arr is not None:
-        query = query.filter(model.Ticket.arrival_station == arr)
-    if dep_base is not None:
-        query = query.filter(model.Ticket.departure_base >= dep_base)
-    if arr_limit is not None:
-        query = query.filter(model.Ticket.arrival_limit <= arr_limit)
+    if after_now:
+        query = query.filter(
+            (model.Ticket.date > datetime.now().date()) |
+            (
+                (model.Ticket.date == datetime.now().date()) &
+                (model.Ticket.departure_base > datetime.now().time())
+            )
+        )
     if reserved is not None:
         query = query.filter(model.Ticket.reserved == reserved)
     if running is not None:

--- a/server/api/main.py
+++ b/server/api/main.py
@@ -3,7 +3,6 @@
 :copyright: (c) 2022 by Hangil Gim.
 :license: MIT, see LICENSE for more details.
 """
-from datetime import datetime
 from multiprocessing import Lock
 from os import environ
 from threading import Thread
@@ -52,8 +51,7 @@ def search_tickets_periodic():
         with SessionLocal() as db_session:
             tickets = crud.get_tickets(
                 db_session=db_session,
-                date=datetime.now().date(),
-                dep_base=datetime.now().time(),
+                after_now=True,
                 reserved=False,
                 running=False,
             )

--- a/server/api/utils.py
+++ b/server/api/utils.py
@@ -134,7 +134,7 @@ def search_trains(ticket: Ticket):
             dep=ticket.departure_station,
             arr=ticket.arrival_station,
             date=ticket.date.strftime("%Y%m%d"),
-            time=max(ticket_datetime, datetime.now()).strftime("%H%M%S"),
+            time=ticket.departure_base.strftime("%H%M%S"),
             train_type=TrainType.KTX,
         )
         for train in trains:


### PR DESCRIPTION
`date`, `dep_base`, `arr_limit` 처럼 날짜와 시간을 각각 인자로 받는 것을 그냥 `after_now`라는 `boolean` 인자를 받아서 지금 이후의 예약만 가져올 수 있게 만들었다.